### PR TITLE
修复京喜签到

### DIFF
--- a/jx_sign.js
+++ b/jx_sign.js
@@ -201,10 +201,13 @@ async function main(help = true) {
 
 // 查询信息
 function signhb(type = 1) {
-  let body = '';
-  if ($.signhb_source === '5') body = `type=0&signhb_source=${$.signhb_source}&smp=&ispp=1&tk=`
+  let functionId = 'signhb/query', body = '';
+  if ($.signhb_source === '5') {
+    functionId = 'signhb/query_jxpp'
+    body = `type=0&signhb_source=${$.signhb_source}&smp=&ispp=1&tk=`
+  }
   return new Promise((resolve) => {
-    $.get(taskUrl("signhb/query", body), async (err, resp, data) => {
+    $.get(taskUrl(functionId, body), async (err, resp, data) => {
       try {
         if (err) {
           console.log(JSON.stringify(err));
@@ -285,8 +288,16 @@ function signhb(type = 1) {
 
 // 签到 助力
 function helpSignhb(smp = '') {
+  let functionId, body;
+  if ($.signhb_source === '5') {
+    functionId = 'signhb/query_jxpp'
+    body = `type=1&signhb_source=${$.signhb_source}&smp=&ispp=1&tk=`
+  } else {
+    functionId = 'signhb/query'
+    body = `type=1&signhb_source=${$.signhb_source}&smp=${smp}&ispp=0&tk=`
+  }
   return new Promise((resolve) => {
-    $.get(taskUrl("signhb/query", `type=1&signhb_source=${$.signhb_source}&smp=${smp}&ispp=1&tk=`), async (err, resp, data) => {
+    $.get(taskUrl(functionId, body), async (err, resp, data) => {
       try {
         if (err) {
           console.log(JSON.stringify(err))
@@ -299,8 +310,11 @@ function helpSignhb(smp = '') {
           for (let key of Object.keys(signlist)) {
             let vo = signlist[key]
             if (vo.istoday === 1) {
-              if (vo.status === 1 && data.todaysign === 1) {
-                // console.log(`今日已签到`)
+              // 猜测：1=已签到；3=未签到
+              if (vo.status === 1 || vo.status === 3) {
+                if (data.todaysign === 1) {
+                  // console.log(`今日已签到`)
+                }
               } else {
                 console.log(`此账号已黑`)
                 $.black = true
@@ -319,14 +333,16 @@ function helpSignhb(smp = '') {
 
 // 任务
 function dotask(task) {
-  let body;
+  let functionId, body;
   if ($.signhb_source === '5') {
+    functionId = 'signhb/dotask_jxpp'
     body = `task=${task}&signhb_source=${$.signhb_source}&ispp=1&sqactive=${$.sqactive}&tk=`
   } else {
-    body = `task=${task}&signhb_source=${$.signhb_source}&ispp=1&tk=`
+    functionId = 'signhb/dotask'
+    body = `task=${task}&signhb_source=${$.signhb_source}&ispp=0&sqactive=&tk=`
   }
   return new Promise((resolve) => {
-    $.get(taskUrl("signhb/dotask", body), async (err, resp, data) => {
+    $.get(taskUrl(functionId, body), async (err, resp, data) => {
         try {
           if (err) {
             console.log(JSON.stringify(err));
@@ -357,7 +373,7 @@ function bxdraw() {
   if ($.signhb_source === '5') {
     body = `ispp=1&sqactive=${$.sqactive}&tk=`
   } else {
-    body = `ispp=1&tk=`
+    body = `ispp=0&sqactive=&tk=`
   }
   return new Promise((resolve) => {
     $.get(taskUrl("signhb/bxdraw", body), async (err, resp, data) => {


### PR DESCRIPTION
京喜签到昨天（03-18）就挂了，提示黑号，实际并没有黑，只是判断的逻辑有问题。
另外接口也进行了更新，否则会提示 1069。

修复前：
![截屏2022-03-19 下午2 36 40](https://user-images.githubusercontent.com/28760483/159110588-10cdbdce-d1c3-4bf9-9325-f7eb1eeb6bf4.png)

修复后：
![截屏2022-03-19 下午2.39.37](https://user-images.githubusercontent.com/28760483/159110648-ff3f154c-a889-4401-9156-89a337c26c88.png)


